### PR TITLE
Added relationships from Distribution to Dataset and from Dataset to Catalogue

### DIFF
--- a/DataServiceRun/examples/example-normalized.json
+++ b/DataServiceRun/examples/example-normalized.json
@@ -59,7 +59,6 @@
     "value": "urn:ngsi-ld:DataServiceDCAT-AP:example"
   },    
   "@context": [
-    2.1.0
     "https://raw.githubusercontent.com/smart-data-models/dataModel.DCAT-AP/master/context.jsonld"
 ]
 }

--- a/DataServiceRun/examples/example-normalized.jsonld
+++ b/DataServiceRun/examples/example-normalized.jsonld
@@ -59,7 +59,6 @@
         "object": "urn:ngsi-ld:DataServiceDCAT-AP:example"
     },
     "@context": [
-      2.1.0
       "https://raw.githubusercontent.com/smart-data-models/dataModel.DataServices/master/context.jsonld"
   ]
   }

--- a/Dataset/examples/example-normalized.json
+++ b/Dataset/examples/example-normalized.json
@@ -26,11 +26,15 @@
        "https://datos.gob.es/es/comment/reply/145778."
     ]
   },
+  "belongsToCatalogue": {
+    "type": "Text",
+    "value": "urn:ngsi-ld:Catalogue:items:MWVK:61846917"
+  },
   "distribution": {
     "type": "array",
     "value": [
-         "urn:ngsi-ld:Distribution:items:KJVK:30944451",
-    "urn:ngsi-ld:Distribution:items:MMWU:84196227"
+      "urn:ngsi-ld:Distribution:items:KJVK:30944451",
+      "urn:ngsi-ld:Distribution:items:MMWU:84196227"
     ]
   },
   "keyword": {

--- a/Dataset/examples/example-normalized.jsonld
+++ b/Dataset/examples/example-normalized.jsonld
@@ -28,11 +28,15 @@
        "https://datos.gob.es/es/comment/reply/145778."
     ]
   },
+  "belongsToCatalogue": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Catalogue:items:MWVK:61846917"
+  },
   "distribution": {
     "type": "Relationship",
     "object": [
-         "urn:ngsi-ld:Distribution:items:KJVK:30944451",
-    "urn:ngsi-ld:Distribution:items:MMWU:84196227"
+      "urn:ngsi-ld:Distribution:items:KJVK:30944451",
+      "urn:ngsi-ld:Distribution:items:MMWU:84196227"
     ]
   },
   "keyword": {

--- a/Dataset/examples/example.json
+++ b/Dataset/examples/example.json
@@ -14,6 +14,7 @@
   "contactPoint": [
     "https://datos.gob.es/es/comment/reply/145778."
   ],
+  "belongsToCatalogue": "urn:ngsi-ld:Catalogue:items:MWVK:61846917",
   "distribution": [
     "urn:ngsi-ld:Distribution:items:KJVK:30944451",
     "urn:ngsi-ld:Distribution:items:MMWU:84196227"

--- a/Dataset/examples/example.jsonld
+++ b/Dataset/examples/example.jsonld
@@ -14,6 +14,7 @@
   "contactPoint": [
     "https://datos.gob.es/es/comment/reply/145778."
   ],
+  "belongsToCatalogue": "urn:ngsi-ld:Catalogue:items:MWVK:61846917",
   "distribution": [
     "urn:ngsi-ld:Distribution:items:KJVK:30944451",
     "urn:ngsi-ld:Distribution:items:MMWU:84196227"

--- a/Dataset/schema.json
+++ b/Dataset/schema.json
@@ -43,13 +43,41 @@
             "description": "Property. Every contact element"
           }
         },
+        "belongsToCatalogue": {
+          "description": "Relationship. It links the Dataset to its parent Catalogue. Model:'https://www.w3.org/ns/dcat#Catalogue'",
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+              "description": "Property. Link to the catalogue"
+            },
+            {
+              "type": "string",
+              "format": "uri",
+              "description": "Property. Link to the catalogue"
+            }
+          ]
+        },
         "distribution": {
           "type": "array",
-          "description": "Relationship. This property links the Dataset to an available Distribution. Model:'http://www.w3.org/ns/dcat#Distribution'",
+          "description": "Relationship. It links the Dataset to one or more of its available Distribution(s). Model:'http://www.w3.org/ns/dcat#Distribution'",
           "items": {
-            "type": "string",
-            "format": "uri",
-            "description": "Property. Every link to a distribution"
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 256,
+                "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+                "description": "Property. Every link to a distribution"
+              },
+              {
+                "type": "string",
+                "format": "uri",
+                "description": "Property. Every link to a distribution"
+              }
+            ]
           }
         },
         "keyword": {

--- a/Dataset/schema.json
+++ b/Dataset/schema.json
@@ -44,7 +44,7 @@
           }
         },
         "belongsToCatalogue": {
-          "description": "Relationship. It links the Dataset to its parent Catalogue. Model:'https://www.w3.org/ns/dcat#Catalogue'",
+          "description": "Relationship. It links the Dataset to its parent Catalogue. Model:'https://www.w3.org/ns/dcat#Catalogue'. Note: this attribute does not belong to the current version of DCAT-AP, 2.1.1",
           "anyOf": [
             {
               "type": "string",
@@ -62,7 +62,7 @@
         },
         "distribution": {
           "type": "array",
-          "description": "Relationship. It links the Dataset to one or more of its available Distribution(s). Model:'http://www.w3.org/ns/dcat#Distribution'",
+          "description": "Relationship. This property links the Dataset to an available Distribution. Model:'http://www.w3.org/ns/dcat#Distribution'",
           "items": {
             "anyOf": [
               {

--- a/Distribution/examples/example-normalized.json
+++ b/Distribution/examples/example-normalized.json
@@ -64,6 +64,10 @@
     "type": "Text",
     "value": ""
   },
+  "belongsToDataset": {
+    "type": "Text",
+    "value": "urn:ngsi-ld:Dataset:items:CHIF:23645981"
+  },
   "page": {
     "type": "array",
     "value": [

--- a/Distribution/examples/example-normalized.jsonld
+++ b/Distribution/examples/example-normalized.jsonld
@@ -40,6 +40,10 @@
     "type": "Property",
     "value": ""
   },
+  "belongsToDataset": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:Dataset:items:CHIF:23645981"
+  },
   "dataProvider": {
     "type": "Property",
     "value": "Meloda.org"

--- a/Distribution/examples/example.json
+++ b/Distribution/examples/example.json
@@ -19,6 +19,7 @@
   "byteSize": 43503,
   "checksum": "H3FR.",
   "compressionFormat": "",
+  "belongsToDataset": "urn:ngsi-ld:Dataset:items:CHIF:23645981",
   "description": [
     "Distribution of open data portals in csv"],
   "page": [],

--- a/Distribution/examples/example.jsonld
+++ b/Distribution/examples/example.jsonld
@@ -19,6 +19,7 @@
   "byteSize": 43503,
   "checksum": "H3FR.",
   "compressionFormat": "",
+  "belongsToDataset": "urn:ngsi-ld:Dataset:items:CHIF:23645981",
   "description": [
     "Distribution of open data portals in csv"
   ],

--- a/Distribution/schema.json
+++ b/Distribution/schema.json
@@ -73,7 +73,7 @@
           "description": "Property. Model:'http://purl.org/dc/terms/MediaType'. This property refers to the format of the file in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file. It SHOULD be expressed using a media type as defined in the official register of media types managed by IANA"
         },
         "belongsToDataset": {
-          "description": "Relationship. It links the Distribution to its parent Dataset. Model:'https://www.w3.org/ns/dcat#Dataset'",
+          "description": "Relationship. It links the Distribution to its parent Dataset. Model:'https://www.w3.org/ns/dcat#Dataset'. Note: this attribute does not belong to the current version of DCAT-AP, 2.1.1",
           "anyOf": [
             {
               "type": "string",

--- a/Distribution/schema.json
+++ b/Distribution/schema.json
@@ -72,6 +72,23 @@
           "type": "string",
           "description": "Property. Model:'http://purl.org/dc/terms/MediaType'. This property refers to the format of the file in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file. It SHOULD be expressed using a media type as defined in the official register of media types managed by IANA"
         },
+        "belongsToDataset": {
+          "description": "Relationship. It links the Distribution to its parent Dataset. Model:'https://www.w3.org/ns/dcat#Dataset'",
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256,
+              "pattern": "^[\\w\\-\\.\\{\\}\\$\\+\\*\\[\\]`|~^@!,:\\\\]+$",
+              "description": "Property. Link to the dataset"
+            },
+            {
+              "type": "string",
+              "format": "uri",
+              "description": "Property. Link to the dataset"
+            }
+          ]
+        },
         "page": {
           "type": "array",
           "description": "Property. Model:'https://schema.org/Text'. This property refers to a page or document about this Distribution.",


### PR DESCRIPTION
This allows for easier and better automation and management of DCAT compliant data within a context broker.
In our case, it greatly helps automize the publishing of data to the EDP.
It is worth noting that relationships between Catalogues, Datasets and Distributions are now bidirectional.