### PR TITLE
feat: add properties to DataService data model

### DIFF
--- a/DataService/examples/example-normalized.json
+++ b/DataService/examples/example-normalized.json
@@ -171,7 +171,7 @@
   },
   "version": {
     "type": "Text",
-    "value": 1.0
+    "value": "1.0"
   },
   "versionNotes": {
     "type": "Text",

--- a/DataService/examples/example-normalized.json
+++ b/DataService/examples/example-normalized.json
@@ -165,6 +165,38 @@
       "fi": "Euroopan avoimen datan portaalin tietopalvelu"
     }
   },
+  "imageSource": {
+    "type": "Text",
+    "value": "https://images.app.goo.gl/ZYWsnKdMG7eaKBs18"
+  },
+  "version": {
+    "type": "Text",
+    "value": 1.0
+  },
+  "versionNotes": {
+    "type": "Text",
+    "value": "Improved the performance of the Data Service"
+  },
+  "disseminationOrganisation": {
+    "type": "StructuredValue",
+    "value": "https://www.comunidad.madrid/"
+  },
+  "dissemination": {
+    "type": "Text",
+    "value": "Available resources on updates."
+  },
+  "reputationOrganisation": {
+    "type": "StructuredValue",
+    "value": "https://www.comunidad.madrid/"
+  },
+  "reputation": {
+    "type": "Text",
+    "value": "Statistics or reports published on user's opinions."
+  },
+  "accessMechanism": {
+    "type": "Text",
+    "value": "The Data Service is accessible via an API."
+  },
   "validationSchema": {
     "type": "Text",
     "value": "https://smart-data-models.github.io/dataModel.DCAT-AP/DataService/schema.json"

--- a/DataService/examples/example-normalized.jsonld
+++ b/DataService/examples/example-normalized.jsonld
@@ -167,6 +167,39 @@
     "type": "Property",
     "value": "https://smart-data-models.github.io/dataModel.DCAT-AP/DataService/schema.json"
   },
+  "imageSource": {
+    "type": "Property",
+    "value": "https://images.app.goo.gl/ZYWsnKdMG7eaKBs18"
+  },
+  "version": {
+    "type": "Property",
+    "value": 1.0,
+    "observedAt": "2025-06-12T14:00:00Z",
+    "versionNotes": {
+      "type": "Property",
+      "value": "Improved the performance of the Data Service"
+    }
+  },
+  "disseminationOrganisation": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:City:ComunidadMadrid"
+  },
+  "dissemination": {
+    "type": "Property",
+    "value": "Available resources on updates."
+  },
+  "reputationOrganisation": {
+    "type": "Relationship",
+    "object": "urn:ngsi-ld:City:ComunidadMadrid"
+  },
+  "reputation": {
+    "type": "Property",
+    "value": "Statistics or reports published on user's opinions."
+  },
+  "accessMechanism": {
+    "type": "Property",
+    "value": "The Data Service is accessible via an API."
+  },
   "@context": [
     "https://smart-data-models.github.io/dataModel.DCAT-AP/context.jsonld"
   ]

--- a/DataService/examples/example-normalized.jsonld
+++ b/DataService/examples/example-normalized.jsonld
@@ -173,7 +173,7 @@
   },
   "version": {
     "type": "Property",
-    "value": 1.0,
+    "value": "1.0",
     "observedAt": "2025-06-12T14:00:00Z",
     "versionNotes": {
       "type": "Property",

--- a/DataService/examples/example.json
+++ b/DataService/examples/example.json
@@ -98,7 +98,7 @@
       "fi": "Euroopan avoimen datan portaalin tietopalvelu"
   },
   "imageSource": "https://images.app.goo.gl/ZYWsnKdMG7eaKBs18",
-  "version": 1.0,
+  "version": "1.0",
   "versionNotes": "Improved the performance of the Data Service",
   "disseminationOrganisation": "https://www.comunidad.madrid/",
   "dissemination": "Available resources on updates.",

--- a/DataService/examples/example.json
+++ b/DataService/examples/example.json
@@ -97,5 +97,13 @@
       "nl": "Dataservice van het Europese open dataportaal",
       "fi": "Euroopan avoimen datan portaalin tietopalvelu"
   },
+  "imageSource": "https://images.app.goo.gl/ZYWsnKdMG7eaKBs18",
+  "version": 1.0,
+  "versionNotes": "Improved the performance of the Data Service",
+  "disseminationOrganisation": "https://www.comunidad.madrid/",
+  "dissemination": "Available resources on updates.",
+  "reputationOrganisation": "https://www.comunidad.madrid/",
+  "reputation": "Statistics or reports published on user's opinions.",
+  "accessMechanism": "The Data Service is accessible via an API.",
   "validationSchema": "https://smart-data-models.github.io/dataModel.DCAT-AP/DataService/schema.json"
 }

--- a/DataService/examples/example.jsonld
+++ b/DataService/examples/example.jsonld
@@ -101,6 +101,19 @@
       "fi": "Euroopan avoimen datan portaalin tietopalvelu"
     }
   },
+  "imageSource": "https://images.app.goo.gl/ZYWsnKdMG7eaKBs18",
+  "version": {
+    "value": 1.0,
+    "observedAt": "2025-06-12T14:00:00Z",
+    "versionNotes": {
+      "value": "Improved the performance of the Data Service"
+    }
+  },
+  "disseminationOrganisation": "urn:ngsi-ld:City:ComunidadMadrid",
+  "dissemination": "Available resources on updates.",
+  "reputationOrganisation": "urn:ngsi-ld:City:ComunidadMadrid",
+  "reputation": "Statistics or reports published on user's opinions.",
+  "accessMechanism": "The Data Service is accessible via an API.",
   "validationSchema": "https://smart-data-models.github.io/dataModel.DCAT-AP/DataService/schema.json",
   "@context": [
     "https://smart-data-models.github.io/dataModel.DCAT-AP/context.jsonld"

--- a/DataService/examples/example.jsonld
+++ b/DataService/examples/example.jsonld
@@ -103,7 +103,7 @@
   },
   "imageSource": "https://images.app.goo.gl/ZYWsnKdMG7eaKBs18",
   "version": {
-    "value": 1.0,
+    "value": "1.0",
     "observedAt": "2025-06-12T14:00:00Z",
     "versionNotes": {
       "value": "Improved the performance of the Data Service"

--- a/DataService/notes.yaml
+++ b/DataService/notes.yaml
@@ -1,15 +1,15 @@
 notesHeader:
-  - Adapted from [DCAT-AP version 3.0.0](https://semiceu.github.io/DCAT-AP/releases/3.0.0/). Some properties have been renamed in order to prevent conflicts with other existing properties. Additionally other properties have been added to maintain compatibility with NGSI standard and other data models.
+  - Adapted from [DCAT-AP version 3.0.0](https://semiceu.github.io/DCAT-AP/releases/3.0.0/). Some properties have been renamed in order to prevent conflicts with other existing properties. Additionally other properties have been added to maintain compatibility with NGSI-LD specification and other data models.
   - Adding of the FAIR principles and MELODA5 dimensions properties:
       - provenance, list of libraries and tools used in the development and execution of the service.
       - lastUpdated, last time at which the data service has been updated in a way that changes its behavior.
-      - operationSpace, Geojson reference to the Data Service, it can be Point, LineString, Polygon, MultiPoint, MultiLineString or MultiPolygon.
-      - address, the mailing address or the organization that provide the Data Service.
+      - operationSpace, GeoJSON reference to the Data Service, it can be Point, LineString, Polygon, MultiPoint, MultiLineString or MultiPolygon.
+      - address, the mailing address of the organization that provide the Data Service.
       - validationSchema, URL to the technical validation schema for the Data Service (JSON Schema) in the Smart Data Models program.
       - license, this property contains the license under which the Data service is made available.
 
 notesMiddle:
-  Some properties have been added to allow for more a wider range of usage. Namely assetProvider and configuration. 
+  Some properties have been added to allow for a more wider range of usage. Namely assetProvider and configuration. 
 
 notesFooter:
   - CHANGELOG DCAT-AP
@@ -20,7 +20,7 @@ notesFooter:
       - landingPage, new property in DCAT-AP 3.0.0, this property refers to a web page that provides access to the Data Service and/or additional information.
       - publisher, new property in DCAT-AP 3.0.0, this property refers to a collection of data that this data service can distribute.
       - theme, new property in DCAT-AP 3.0.0, this property refers to a category of the Data Service.
-      - endPointURL is translated to endpointURL.
-      - endPointDescription is translated to endpointDescription.
-      - serverDataset description is modified from Property to Relationship of Datasets.
+      - endpointUrl is translated to endpointURL.
+      - endpointDescription is translated to endpointDescription.
+      - servesDataset description is modified from Property to Relationship of Datasets.
       - title/description properties were represented as an array of strings, each entry in the array being a translation in a specific language. They are represented now as LanguageProperty defined in the ETSI NGSI-LD specification to offer multilanguage support of the Data Service data.

--- a/DataService/schema.json
+++ b/DataService/schema.json
@@ -1053,6 +1053,38 @@
             }
           ]
         },
+        "imageSource": {
+          "type": "string",
+          "description": "Property. Model:'https://schema.org/url'. URL to an image that can be used to accompany the presentation of the Data Service."
+        },
+        "version": {
+          "type": "string",
+          "description": "Property. Model:'https://www.w3.org/ns/dcat#version'. The version indicator (name or identifier) of a resource."
+        },
+        "versionNotes": {
+          "type": "string",
+          "description": "Property. Model:'https://www.w3.org/TR/vocab-adms/#adms-versionnotes'. A description of changes between this version and the previous version of the resource."
+        },
+        "disseminationOrganisation": {
+          "type": "string",
+          "description": "Relationship. Model:'http://xmlns.com/foaf/0.1/Agent'. The organisation in charge of the dissemenation of the Data Service."
+        },
+        "dissemination": {
+          "type": "string",
+          "description": "Property. A summary of the dissemination effort that is done by the organisation (not systematic, available resources on updates, proactive dissemination / push dissemination,...)."
+        },
+        "reputationOrganisation": {
+          "type": "string",
+          "description": "Relationship. Model:'http://xmlns.com/foaf/0.1/Agent'. The organisation in charge of the reputation of the Data Service."
+        },
+        "reputation": {
+          "type": "string",
+          "description": "Property. A summary of the reputation effort that is done by the organisation (no information, statistics or reports published on user's opinions, indicators or rankings on reputation of the data source,...)."
+        },
+        "accessMechanism": {
+          "type": "string",
+          "description": "Property. How the information can be accessed (Web access or unique URL parameters to dataset, Web Access unique with parameters to single data, API or query language,...)."
+        },
         "validationSchema": {
           "type": "string",
           "description": "Property. Model:'https://schema.org/url'. URL to the technical validation schema for the DataService (JSON Schema) in the Smart Data Models program."


### PR DESCRIPTION
* Renamed `endPointURL` to `endpointURL`
* Renamed `endPointDescription` to `endpointDescription`
* Added `disseminationOrganisation`, `dissemination`, `reputationOrganisation`, `reputation` and `accessMechanism` (from Meloda5 metrics)
* Added `imageSource`
* Added `versionNotes`